### PR TITLE
scripts: prerelease -> prepublish

### DIFF
--- a/packages/babel-preset-jsx/package.json
+++ b/packages/babel-preset-jsx/package.json
@@ -10,7 +10,7 @@
   "private": false,
   "scripts": {
     "build": "rollup -c",
-    "prerelease": "yarn build"
+    "prepublish": "yarn build"
   },
   "dependencies": {
     "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0",


### PR DESCRIPTION
It looks like the reason of this issue 😂

[Error: Cannot find module '@vue/babel-preset-jsx' from <Project Path> #12](https://github.com/vuejs/jsx/issues/12)