### PR TITLE
V model component fix

### DIFF
--- a/packages/babel-sugar-v-model/package.json
+++ b/packages/babel-sugar-v-model/package.json
@@ -38,7 +38,7 @@
     "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0",
     "@vue/babel-plugin-transform-vue-jsx": "^0.1.0",
     "camelcase": "^5.0.0",
-	 "html-tags": "2.0.0",
+	"html-tags": "2.0.0",
 	"svg-tags": "1.0.0"
   },
   "nyc": {

--- a/packages/babel-sugar-v-model/package.json
+++ b/packages/babel-sugar-v-model/package.json
@@ -37,7 +37,9 @@
     "@babel/plugin-syntax-jsx": "^7.0.0-rc.3",
     "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0",
     "@vue/babel-plugin-transform-vue-jsx": "^0.1.0",
-    "camelcase": "^5.0.0"
+    "camelcase": "^5.0.0",
+	 "html-tags": "2.0.0",
+	"svg-tags": "1.0.0"
   },
   "nyc": {
     "exclude": [

--- a/packages/babel-sugar-v-model/src/index.js
+++ b/packages/babel-sugar-v-model/src/index.js
@@ -1,6 +1,8 @@
 import camelCase from 'camelcase'
 import syntaxJsx from '@babel/plugin-syntax-jsx'
-
+import htmlTags from 'html-tags'
+import svgTags from 'svg-tags'
+	
 const RANGE_TOKEN = '__r'
 
 const cachedCamelCase = (() => {
@@ -109,9 +111,16 @@ const isComponent = (t, path) => {
   const name = path.get('name')
   if (t.isJSXMemberExpression(name)) {
     return true
-  } else {
-    const firstChar = name.get('name').node[0]
-    return firstChar >= 'A' && firstChar <= 'Z'
+  }
+  else  {
+	  const tagName =  getTagName(t, path)
+      const firstChar = tagName.charAt(0)
+	  if ((firstChar >= 'A' && firstChar <= 'Z') || (!htmlTags.includes(tagName) && !svgTags.includes(tagName)))   {
+	  	return true
+	  }
+	  else {
+	  	return false
+	  }
   }
 }
 


### PR DESCRIPTION
This pull request:

- Allows components that are not capltalised to use `v-model`. (https://github.com/vuejs/jsx/issues/15)
e.g: `<my-component v-model={this.example} />` 

- Fixes event bindings (`update` and `change`) for generic components, along with event modifiers such as `lazy` and `trim`. (https://github.com/vuejs/jsx/issues/20)

- Prevents `model` from being passed to the `directives` list, as this is unnecessary and can cause issues with other components. (https://github.com/vuejs/jsx/issues/20)