### PR TITLE
Add files field to package.json

### DIFF
--- a/packages/babel-helper-vue-jsx-merge-props/package.json
+++ b/packages/babel-helper-vue-jsx-merge-props/package.json
@@ -7,6 +7,7 @@
   "author": "Evan You",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "build:testing": "rollup -c rollup.config.testing.js",
     "build": "rollup -c",

--- a/packages/babel-plugin-transform-vue-jsx/package.json
+++ b/packages/babel-plugin-transform-vue-jsx/package.json
@@ -7,6 +7,7 @@
   "author": "Evan You",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "pretest:snapshot": "yarn build:test",
     "test:snapshot": "nyc --reporter=html --reporter=text-summary ava -v test/snapshot.js",

--- a/packages/babel-preset-jsx/package.json
+++ b/packages/babel-preset-jsx/package.json
@@ -8,6 +8,7 @@
   "author": "Nick Messing <dot.nick.dot.messing@gmail.com>",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "build": "rollup -c",
     "prerelease": "yarn build"

--- a/packages/babel-preset-jsx/package.json
+++ b/packages/babel-preset-jsx/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "Babel preset for Vue JSX",
   "main": "dist/plugin.cjs.js",
-  "module": "dist/plugin.js",
   "repository": "https://github.com/vuejs/jsx/tree/master/packages/babel-sugar-event-modifiers",
   "author": "Nick Messing <dot.nick.dot.messing@gmail.com>",
   "license": "MIT",

--- a/packages/babel-preset-jsx/rollup.config.js
+++ b/packages/babel-preset-jsx/rollup.config.js
@@ -8,9 +8,5 @@ export default {
       file: 'dist/plugin.cjs.js',
       format: 'cjs',
     },
-    {
-      file: 'dist/plugin.js',
-      format: 'esm',
-    },
   ],
 }

--- a/packages/babel-sugar-functional-vue/package.json
+++ b/packages/babel-sugar-functional-vue/package.json
@@ -7,6 +7,7 @@
   "author": "Nick Messing <dot.nick.dot.messing@gmail.com>",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "prepublish": "yarn build",
     "build": "rollup -c",

--- a/packages/babel-sugar-inject-h/package.json
+++ b/packages/babel-sugar-inject-h/package.json
@@ -7,6 +7,7 @@
   "author": "Nick Messing <dot.nick.dot.messing@gmail.com>",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "prepublish": "yarn build",
     "build": "rollup -c",

--- a/packages/babel-sugar-v-model/package.json
+++ b/packages/babel-sugar-v-model/package.json
@@ -7,6 +7,7 @@
   "author": "Nick Messing <dot.nick.dot.messing@gmail.com>",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "pretest:snapshot": "yarn build:test",
     "test:snapshot": "nyc --reporter=html --reporter=text-summary ava -v test/snapshot.js",

--- a/packages/babel-sugar-v-on/package.json
+++ b/packages/babel-sugar-v-on/package.json
@@ -7,6 +7,7 @@
   "author": "Nick Messing <dot.nick.dot.messing@gmail.com>",
   "license": "MIT",
   "private": false,
+  "files": [],
   "scripts": {
     "pretest:snapshot": "yarn build:test",
     "test:snapshot": "nyc --reporter=html --reporter=text-summary ava -v test/snapshot.js",


### PR DESCRIPTION
I left `files` fields empty because all files required for it to work are automatically included as described in [npm docs](https://docs.npmjs.com/files/package.json#files). Only package.json and file from `main` field are required.