### PR TITLE
Treat string as component if declared in scope

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/package.json
+++ b/packages/babel-plugin-transform-vue-jsx/package.json
@@ -37,7 +37,9 @@
     "@babel/helper-module-imports": "^7.0.0-rc.3",
     "@babel/plugin-syntax-jsx": "^7.0.0-rc.3",
     "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0",
-    "lodash.kebabcase": "^4.1.1"
+    "html-tags": "^2.0.0",
+    "lodash.kebabcase": "^4.1.1",
+    "svg-tags": "^1.0.0"
   },
   "peerDependencies": {
     "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0"

--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -1,6 +1,8 @@
 import syntaxJsx from '@babel/plugin-syntax-jsx'
 import { addDefault } from '@babel/helper-module-imports'
 import kebabcase from 'lodash.kebabcase'
+import htmlTags from 'html-tags'
+import svgTags from 'svg-tags'
 
 const xlinkRE = /^xlink([A-Z])/
 const rootAttributes = ['class', 'style', 'key', 'ref', 'refInFor', 'slot', 'scopedSlots', 'model']
@@ -40,7 +42,7 @@ const getTag = (t, path) => {
   const namePath = path.get('name')
   if (t.isJSXIdentifier(namePath)) {
     const name = namePath.get('name').node
-    if (path.scope.hasBinding(name)) {
+    if (path.scope.hasBinding(name) && !htmlTags.includes(name) && !svgTags.includes(name)) {
       return t.identifier(name)
     } else {
       return t.stringLiteral(name)

--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -40,7 +40,7 @@ const getTag = (t, path) => {
   const namePath = path.get('name')
   if (t.isJSXIdentifier(namePath)) {
     const name = namePath.get('name').node
-    if (name[0] > 'A' && name[0] < 'Z') {
+    if (path.scope.hasBinding(name)) {
       return t.identifier(name)
     } else {
       return t.stringLiteral(name)

--- a/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
+++ b/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
@@ -25,6 +25,12 @@ const tests = [
     to: `render(h => h("div", ["test"]));`,
   },
   {
+    name: 'HTML tag if variable in scope',
+    from: `const div = {}; render(h => <div>test</div>)`,
+    to: `const div = {};
+render(h => h("div", ["test"]));`,
+  },
+  {
     name: 'Tag & Component',
     from: `const Alpha = {}; render(h => [<Alpha>test</Alpha>, <Beta>test</Beta>])`,
     to: `const Alpha = {};

--- a/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
+++ b/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
@@ -25,9 +25,10 @@ const tests = [
     to: `render(h => h("div", ["test"]));`,
   },
   {
-    name: 'Uppercase component',
-    from: `render(h => <Div>test</Div>)`,
-    to: `render(h => h(Div, ["test"]));`,
+    name: 'Tag & Component',
+    from: `const Alpha = {}; render(h => [<Alpha>test</Alpha>, <Beta>test</Beta>])`,
+    to: `const Alpha = {};
+render(h => [h(Alpha, ["test"]), h("Beta", ["test"])]);`,
   },
   {
     name: 'MemberExpression component',

--- a/packages/babel-plugin-transform-vue-jsx/yarn.lock
+++ b/packages/babel-plugin-transform-vue-jsx/yarn.lock
@@ -2572,6 +2572,11 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-tags@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
+  integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -4590,6 +4595,11 @@ supports-color@^5.0.0, supports-color@^5.3.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
     has-flag "^3.0.0"
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
 symbol-observable@^0.2.2:
   version "0.2.4"


### PR DESCRIPTION
Since we recommend using `PascalCase` for all components and there is a global namespace where componetns can be defined, it would make sense to support stuff like:
```js
// main.js
import Vue from 'vue'
import ComponentLibrary from 'vue-component-library'
import App from './App'

Vue.use(ComponentLibrary) // registers component Alpha

new Vue({
  el: '#app',
  render() { return <App /> },
})
```
```js
// App.js
import Beta from './Beta'

export default {
  render() {
    return (
      <div>
        <Alpha /> {/* Declared in global namespace */}
        <Beta /> {/* Declared in local scope */}
      </div>
    )
  }
}
```
This PR allows it by transpiling `App.js` into:
```js
// App.js
import Beta from './Beta'

export default {
  render() {
    return h('div', [h('Alpha'), h(Beta)])
  }
}
```