### PR TITLE
fix: remove extraneous peer deps

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/package.json
+++ b/packages/babel-plugin-transform-vue-jsx/package.json
@@ -42,9 +42,6 @@
     "lodash.kebabcase": "^4.1.1",
     "svg-tags": "^1.0.0"
   },
-  "peerDependencies": {
-    "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0"
-  },
   "nyc": {
     "exclude": [
       "dist",

--- a/packages/babel-preset-jsx/package.json
+++ b/packages/babel-preset-jsx/package.json
@@ -23,8 +23,5 @@
   "devDependencies": {
     "rollup": "^0.67.4",
     "rollup-plugin-babel-minify": "^6.2.0"
-  },
-  "peerDependencies": {
-    "@vue/babel-helper-vue-jsx-merge-props": "^0.1.0"
   }
 }


### PR DESCRIPTION
Now that they're already included in the `dependencies` field.
Also the version ranges are outdated.