### PR TITLE
fix: filter out jsx comments in `getChildren`

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -82,7 +82,7 @@ const getChildren = (t, paths) =>
       /* istanbul ignore next */
       throw new Error(`getChildren: ${path.type} is not supported`)
     })
-    .filter(el => el !== null)
+    .filter(el => el !== null && !t.isJSXEmptyExpression(el))
 
 /**
  * Add attribute to an attributes object

--- a/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
+++ b/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
@@ -325,6 +325,11 @@ h("MyComponent", _mergeJSXProps([{
   }
 }]));`,
   },
+  {
+    name: 'JSX comments',
+    from: `<div><p>jsx</p>{/* <p>comment</p> */}</div>`,
+    to: `h("div", [h("p", ["jsx"])]);`
+  }
 ]
 
 tests.forEach(({ name, from, to }) => test(name, async t => t.is(await transpile(from), to)))


### PR DESCRIPTION
fixes #46