### PR TITLE
fix: adds validation that jsx is in scope of arrow function instead of method check

### DIFF
--- a/packages/babel-sugar-functional-vue/src/index.js
+++ b/packages/babel-sugar-functional-vue/src/index.js
@@ -1,23 +1,6 @@
 import syntaxJsx from '@babel/plugin-syntax-jsx'
 
 /**
- * Check if expression is in method
- * @param t
- * @param path
- * @param parentLimitPath
- * @returns boolean
- */
-const isInMethod = (t, path, parentLimitPath) => {
-  if (!path || path === parentLimitPath) {
-    return false
-  }
-  if (t.isObjectMethod(path)) {
-    return true
-  }
-  return isInMethod(t, path.parentPath, parentLimitPath)
-}
-
-/**
  * Check path has JSX
  * @param t
  * @param path
@@ -25,12 +8,23 @@ const isInMethod = (t, path, parentLimitPath) => {
  */
 const hasJSX = (t, path) => {
   let hasJSX = false
+  let parentScope
 
   path.traverse({
     JSXElement(elPath) {
-      if (!isInMethod(t, elPath, path)) {
+      if (parentScope === elPath.scope) {
         hasJSX = true
       }
+    },
+
+    ArrowFunctionExpression(blockPath) {
+      const isParent = blockPath.parentPath === path
+
+      if (!isParent) {
+        return
+      }
+
+      parentScope = blockPath.scope
     },
   })
 

--- a/packages/babel-sugar-functional-vue/test/test.js
+++ b/packages/babel-sugar-functional-vue/test/test.js
@@ -77,6 +77,23 @@ const tests = [
 });`,
   },
   {
+    name: 'Wrapper of function does not compile',
+    from: `const Wrapped = () => wrap(() => <span />)`,
+    to: `const Wrapped = () => wrap(() => <span />);`,
+  },
+  {
+    name: 'If JSX in function arguments does not compile',
+    from: `const Wrapped = (jsx = () => <span />) => jsx`,
+    to: `const Wrapped = (jsx = () => <span />) => jsx;`,
+  },
+  {
+    name: 'If JSX in nested function does not compile',
+    from: `const Wrapped = () => function () { return <span /> }`,
+    to: `const Wrapped = () => function () {
+  return <span />;
+};`,
+  },
+  {
     name: 'Default export',
     from: `export default ({ props, listeners }) => <div onClick={listeners.click}>{props.msg}</div>`,
     to: `export default {


### PR DESCRIPTION
fixes #88 