### PR TITLE
Arrow function support for JSX h injection

### DIFF
--- a/packages/babel-sugar-inject-h/src/index.js
+++ b/packages/babel-sugar-inject-h/src/index.js
@@ -19,19 +19,13 @@ const firstParamIsH = (t, path) => {
  */
 const hasJSX = (t, path) => {
   const JSXChecker = {
-    hasInnerFunction: false,
     hasJSX: false,
   }
   path.traverse(
     {
       JSXElement() {
-        if (!this.hasInnerFunction) {
-          this.hasJSX = true
-        }
+        this.hasJSX = true
       },
-      Function() {
-        this.hasInnerFunction = true
-      }
     },
     JSXChecker,
   )
@@ -67,23 +61,7 @@ export default babel => {
               return
             }
 
-            const isAddParameter = path.node.key === undefined || path.node.key.name === 'render'
-
-            if (isAddParameter) {
-              path.node.params = [t.identifier('h'), ...path.node.params]
-            } else {
-              path
-                .get('body')
-                .unshiftContainer(
-                  'body',
-                  t.variableDeclaration('const', [
-                    t.variableDeclarator(
-                      t.identifier('h'),
-                      t.memberExpression(t.thisExpression(), t.identifier('$createElement')),
-                    ),
-                  ]),
-                )
-            }
+            path.node.params = [t.identifier('h'), ...path.node.params]
           },
         })
       },

--- a/packages/babel-sugar-inject-h/src/index.js
+++ b/packages/babel-sugar-inject-h/src/index.js
@@ -56,26 +56,28 @@ export default babel => {
     visitor: {
       Program(path) {
         path.traverse({
-          'ObjectMethod|ClassMethod'(path) {
+          'Function'(path) {
             if (firstParamIsH(t, path) || !hasJSX(t, path) || isInsideJSXExpression(t, path)) {
               return
             }
 
-            const isRender = path.node.key.name === 'render'
+            const isAddParameter = path.node.key === undefined || path.node.key.name === 'render'
 
-            path
-              .get('body')
-              .unshiftContainer(
-                'body',
-                t.variableDeclaration('const', [
-                  t.variableDeclarator(
-                    t.identifier('h'),
-                    isRender
-                      ? t.memberExpression(t.identifier('arguments'), t.numericLiteral(0), true)
-                      : t.memberExpression(t.thisExpression(), t.identifier('$createElement')),
-                  ),
-                ]),
-              )
+            if (isAddParameter) {
+              path.node.params = [t.identifier('h'), ...path.node.params]
+            } else {
+              path
+                .get('body')
+                .unshiftContainer(
+                  'body',
+                  t.variableDeclaration('const', [
+                    t.variableDeclarator(
+                      t.identifier('h'),
+                      t.memberExpression(t.thisExpression(), t.identifier('$createElement')),
+                    ),
+                  ]),
+                )
+            }
           },
         })
       },

--- a/packages/babel-sugar-inject-h/src/index.js
+++ b/packages/babel-sugar-inject-h/src/index.js
@@ -19,13 +19,19 @@ const firstParamIsH = (t, path) => {
  */
 const hasJSX = (t, path) => {
   const JSXChecker = {
+    hasInnerFunction: false,
     hasJSX: false,
   }
   path.traverse(
     {
       JSXElement() {
-        this.hasJSX = true
+        if (!this.hasInnerFunction) {
+          this.hasJSX = true
+        }
       },
+      Function() {
+        this.hasInnerFunction = true
+      }
     },
     JSXChecker,
   )

--- a/packages/babel-sugar-inject-h/test/test.js
+++ b/packages/babel-sugar-inject-h/test/test.js
@@ -112,6 +112,15 @@ const tests = [
 };`,
   },
   {
+    name: 'Nested arrow functions',
+    from: `const func = () => ({
+      render: (foo) => <div>test</div>
+    })`,
+    to: `const func = () => ({
+  render: (h, foo) => <div>test</div>
+});`,
+  },
+  {
     name: 'Function declaration',
     from: `function foo(bar) {
       return <div>test</div>;

--- a/packages/babel-sugar-inject-h/test/test.js
+++ b/packages/babel-sugar-inject-h/test/test.js
@@ -96,11 +96,37 @@ const tests = [
       }
     }`,
     to: `const obj = {
-  render() {
-    const h = arguments[0];
+  render(h) {
     return <div>test</div>;
   }
 
+};`,
+  },
+  {
+    name: 'Arrow function',
+    from: `const obj = {
+      render: (foo) => <div>test</div>
+    }`,
+    to: `const obj = {
+  render: (h, foo) => <div>test</div>
+};`,
+  },
+  {
+    name: 'Function declaration',
+    from: `function foo(bar) {
+      return <div>test</div>;
+    }`,
+    to: `function foo(h, bar) {
+  return <div>test</div>;
+}`,
+  },
+  {
+    name: 'Function expression',
+    from: `const foo = function (bar) {
+      return <div>test</div>;
+    };`,
+    to: `const foo = function (h, bar) {
+  return <div>test</div>;
 };`,
   },
 ]

--- a/packages/babel-sugar-inject-h/test/test.js
+++ b/packages/babel-sugar-inject-h/test/test.js
@@ -27,8 +27,7 @@ const tests = [
       }
     }`,
     to: `const obj = {
-  method() {
-    const h = this.$createElement;
+  method(h) {
     return <div>test</div>;
   }
 
@@ -46,8 +45,7 @@ const tests = [
       }
     }`,
     to: `const obj = {
-  method() {
-    const h = this.$createElement;
+  method(h) {
     return <div foo={{
       render() {
         return <div>bar</div>;
@@ -66,8 +64,7 @@ const tests = [
       }
     }`,
     to: `const obj = {
-  get method() {
-    const h = this.$createElement;
+  get method(h) {
     return <div>test</div>;
   }
 
@@ -81,8 +78,7 @@ const tests = [
       }
     }`,
     to: `const obj = {
-  method(hey) {
-    const h = this.$createElement;
+  method(h, hey) {
     return <div>test</div>;
   }
 
@@ -110,15 +106,6 @@ const tests = [
     to: `const obj = {
   render: (h, foo) => <div>test</div>
 };`,
-  },
-  {
-    name: 'Nested arrow functions',
-    from: `const func = () => ({
-      render: (foo) => <div>test</div>
-    })`,
-    to: `const func = () => ({
-  render: (h, foo) => <div>test</div>
-});`,
   },
   {
     name: 'Function declaration',


### PR DESCRIPTION
The current implementation of babel-sugar-inject-h does not support arrow functions. However, it is possible to add arrow function support with just some small adjustments. Here you go.