### PR TITLE
fix: add support for jsx camel case event binding

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -166,7 +166,15 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
 
   prefix = prefixes.find(el => name.startsWith(el)) || 'attrs'
   name = name.replace(new RegExp(`^${prefix}\-?`), '')
-  name = name[0].toLowerCase() + name.substr(1)
+
+  // in jsx, event binding use Camel case, such as `onClick`, `onMouseDown`;
+  // in HTML Specification, event binding is all lower case, such as `onclick`, `onmousedown`
+  // so for `on` and `nativeOn` attribute in jsx, transform `name` to all lower case
+  if (prefix === 'on' || prefix === 'nativeOn') {
+    name = name.toLowerCase()
+  } else {
+    name = name[0].toLowerCase() + name.substr(1)
+  }
 
   const valuePath = path.get('value')
   let value


### PR DESCRIPTION
## Why
In jsx, event binding use Camel case, such as `onClick`, `onMouseDown`.
In HTML Specification, event binding is all lower case, such as `onclick`, `onmousedown`.
So for `on` and `nativeOn` attribute in jsx, transform `name` to all lower case.

## Before fix
source code:
```jsx
<div onMouseDown={() => {}}></div>
```
transform to:
```js
render: function render() {
  var h = arguments[0];
  return h("div", {
    "on": {
      "mouseDown": function() {}
    },
    }
  }, []);
}
```
This will render to `onmouseDown` event to `div`, not `onmousedown`.

## After fix
```jsx
<div onMouseDown={() => {}}></div>
```
transform to:
```js
render: function render() {
  var h = arguments[0];
  return h("div", {
    "on": {
      "mousedown": function() {}
    },
    }
  }, []);
}
```


Topic on Stackoverflow: [Vue jsx event handlers](https://stackoverflow.com/questions/53413800/vue-jsx-event-handlers/59818327#59818327).

