### PR TITLE
Feature/custom component prefix on

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -166,7 +166,15 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
 
   prefix = prefixes.find(el => name.startsWith(el)) || 'attrs'
   name = name.replace(new RegExp(`^${prefix}\-?`), '')
-  name = name[0].toLowerCase() + name.substr(1)
+
+  // in jsx, event binding use Camel case, such as `onClick`, `onMouseDown`;
+  // in HTML Specification, event binding is all lower case, such as `onclick`, `onmousedown`
+  // so for `on` and `nativeOn` attribute in jsx, transform `name` to all lower case
+  if (prefix === 'on' || prefix === 'nativeOn') {
+    name = name.toLowerCase()
+  } else {
+    name = name[0].toLowerCase() + name.substr(1)
+  }
 
   const valuePath = path.get('value')
   let value

--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -167,7 +167,7 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
   prefix = prefixes.find(el => name.startsWith(el)) || 'attrs'
 
   // For custom components(which tag name is not html tag), event binding need to use `nativeOn` but not `on`
-  // `on` prefix should transfrom to `attrs`
+  // `on` prefix should transform to `attrs`
   if (!htmlTags.includes(tagName) && prefix === 'on') {
     prefix = 'attrs'
   }

--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -165,6 +165,13 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
     ;[name, argument] = name.split(':')
 
   prefix = prefixes.find(el => name.startsWith(el)) || 'attrs'
+
+  // For custom components(which tag name is not html tag), event binding need to use `nativeOn` but not `on`
+  // `on` prefix should transfrom to `attrs`
+  if (!htmlTags.includes(tagName) && prefix === 'on') {
+    prefix = 'attrs'
+  }
+
   name = name.replace(new RegExp(`^${prefix}\-?`), '')
 
   // in jsx, event binding use Camel case, such as `onClick`, `onMouseDown`;


### PR DESCRIPTION
## Why
 For custom components(which tag name is not html tag), event binding need to use `nativeOn` but not `on`.
 So `on` prefix in custom component should transform to `attrs`.

## Example
When render custom component use jsx, such as [storybook vue example](https://storybook.js.org/docs/guides/guide-vue/#step-4-write-your-stories):
```jsx
export const withText = () => ({
    render: (h) => <my-component
        onChange={() => {}}
        nativeOnTest={() => {}}
        myProp="test">with text
        </my-component>
    });
```

Before fix:
```js
function withText() {
  return {
    render: function render(h) {
      return h("my-component", {
        "on": {
          "change": function change() {}
        },
        "nativeOn": {
          "test": function test() {}
        },
        "attrs": {
          "myProp": "test"
        }
      }, ["with text"]);
    }
  };
}
```

`onChange` transform to `on` event of `my-component`.

After fix: 
```js
function withText() {
  return {
    render: function render(h) {
      return h("my-component", {
        "attrs": {
          "onChange": function onChange() {},
          "myProp": "test"
        },
        "nativeOn": {
          "test": function test() {}
        }
      }, ["with text"]);
    }
  };
}
```

`onChange` transform to `onChange` attribute of `my-component`, and render as Props inside `my-component` as expected.

## EOF

