### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -166,7 +166,7 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
 
   prefix = prefixes.find(el => name.startsWith(el)) || 'attrs'
   name = name.replace(new RegExp(`^${prefix}\-?`), '')
-  name = name[0].toLowerCase() + name.substr(1)
+  name = name[0].toLowerCase() + name.slice(1)
 
   const valuePath = path.get('value')
   let value
@@ -193,7 +193,7 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
     attributes[name] = value
   } else {
     if (isDirective(name)) {
-      name = kebabcase(name.substr(1))
+      name = kebabcase(name.slice(1))
       prefix = 'directives'
     } else {
       name = [name, ...modifiers].join('_')


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.