### PR TITLE
fix: h is not in current instance but in children

### DIFF
--- a/packages/babel-sugar-composition-api-inject-h/src/index.js
+++ b/packages/babel-sugar-composition-api-inject-h/src/index.js
@@ -23,6 +23,58 @@ const hasJSX = (t, path) => {
   return JSXChecker.hasJSX
 }
 
+/**
+ * Check if first parameter is `h`
+ * @param t
+ * @param path ObjectMethod | ClassMethod
+ * @returns boolean
+ */
+const firstParamIsH = (t, path) => {
+  const params = path.get('params')
+  return params.length && t.isIdentifier(params[0]) && params[0].node.name === 'h'
+}
+
+
+/**
+ * Check if is inside a JSX expression
+ * @param t
+ * @param path ObjectMethod | ClassMethod
+ * @returns boolean
+ */
+const isInsideJSXExpression = (t, path) => {
+  if (!path.parentPath) {
+    return false
+  }
+  if (t.isJSXExpressionContainer(path.parentPath)) {
+    return true
+  }
+  return isInsideJSXExpression(t, path.parentPath)
+}
+
+/**
+ * Check if body has declared 'h'
+ * @param t
+ * @param path ObjectMethod | ClassMethod
+ * @returns boolean
+ */
+const hasDeclareH = (t, path) => {
+  const hChecker = {
+    hasDeclareH: false
+  }
+  path.traverse({
+    VariableDeclaration(varPath) {
+      varPath.traverse({
+        Identifier(p) {
+          if (p.node.name === 'h') {
+            hChecker.hasDeclareH = true
+          }
+        }
+      })
+    }
+  })
+  return hChecker.hasDeclareH
+}
+
 // remove `var h = this.$createElement;` in `setup()`
 const remove$createElement = (t, path) => {
   path.traverse({
@@ -50,22 +102,55 @@ const remove$createElement = (t, path) => {
 
 // auto import `h` from `@vue/composition-api`
 const autoImportH = (t, path) => {
-  if (hasJSX(t, path)) {
-    const importNodes = path
-      .get('body')
-      .filter(p => p.isImportDeclaration())
-      .map(p => p.node)
-    const vcaImportNodes = importNodes.filter(p => p.source.value === importSource)
-    const hasH = vcaImportNodes.some(p => p.specifiers.some(s => t.isImportSpecifier(s) && s.local.name === 'h'))
-    if (!hasH) {
-      const vcaImportSpecifier = t.importSpecifier(t.identifier('h'), t.identifier('h'))
-      if (vcaImportNodes.length > 0) {
-        vcaImportNodes[0].specifiers.push(vcaImportSpecifier)
+  path.traverse({
+    'ObjectMethod|ObjectProperty|ClassMethod'(path1) {
+      if (!hasJSX(t, path1)) return
+      if (path1.node.key.name === 'setup') {
+        if (hasDeclareH(t, path1)) return
+        const importNodes = path
+          .get('body')
+          .filter(p => p.isImportDeclaration())
+          .map(p => p.node)
+        const vcaImportNodes = importNodes.filter(p => p.source.value === importSource)
+        const hasVcaImportNodes = vcaImportNodes.some(p => p.specifiers.some(s => (t.isImportSpecifier(s) && s.local.name === 'getCurrentInstance')))
+        if (!hasVcaImportNodes) {
+          const vcaImportSpecifier = t.importSpecifier(t.identifier('getCurrentInstance'), t.identifier('getCurrentInstance'))
+          if (vcaImportNodes.length > 0) {
+            vcaImportNodes[0].specifiers.push(vcaImportSpecifier)
+          } else {
+            path.unshiftContainer('body', t.importDeclaration([vcaImportSpecifier], t.stringLiteral(importSource)))
+          }
+        }
+        const hDeclaration = t.variableDeclarator(
+          t.identifier('h'),
+          t.identifier('getCurrentInstance().proxy.$createElement'
+        ))
+        const hNode = t.variableDeclaration('const', [hDeclaration])
+        path1
+          .get('body')
+          .unshiftContainer(
+            'body',
+            hNode
+          )
       } else {
-        path.unshiftContainer('body', t.importDeclaration([vcaImportSpecifier], t.stringLiteral(importSource)))
+        if (firstParamIsH(t, path1) || isInsideJSXExpression(t, path1) || hasDeclareH(t, path1)) return
+        const isRender = path1.node.key.name === 'render'
+        path1
+          .get('body')
+          .unshiftContainer(
+            'body',
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                t.identifier('h'),
+                isRender
+                  ? t.memberExpression(t.identifier('arguments'), t.numericLiteral(0), true)
+                  : t.memberExpression(t.thisExpression(), t.identifier('$createElement')),
+              ),
+            ]),
+          )
       }
     }
-  }
+  })
 }
 
 export default babel => {


### PR DESCRIPTION
**background**: 
Now our team is readying to migrate from vue2 to vue3. First, we need to migrate jsx form options to setup.

 **problems**: 
1. project throw "unknown custom element: <my-component> - did you register the component correctly" when using babel-sugar-composition-api-inject-h.
2. css style has expired if we don't use v-deep what we used in options jsx. 
3. jsx in option's method or data will has above these problems, too.

**cause**: 
’h‘ is lastChildrenInstance().proxy.$createElement when using 'import { h } from '@vue/composition-api', because using vue.mixin realize the 'compostion-api'. so, we need true currentInstanceH to solve the problems.

#### it won't work with 'babel-sugar-composition-api-inject-h'
```
<script>
import MyComponent from '../my-component'
export default  {
  components: { MyComponent },
  setup() {
    // because using ‘h’ method for the first time is the last mixin childrenInstance().proxy.$createElement.
    // so we need declare 'const h = getCurrentInstance().proxy.$createElement' in setup block.

    //  throw ''unknown custom element: <my-component> - did you register the component correctly" 
    const renderMyComponent = () => <my-component class="font-20">hello world</my-component>

    // it will work
    const renderMyComponent = () => <MyComponent class="font-20">hello world</my-component>

    // method or data options jsx will occur the same problems.
    // it's so sad to update old code when we using so many jsx and outbreak bug easily. 
  },
  render () {
     // old vue2 code will throw ''unknown custom element: <my-component> - did you register the component correctly" 
     //  after we enable { compositionAPI: true }. 
     // however, it run  correctly if we disable { compositionAPI: true }. 
     //  we can't compatible old jsx's code.
     // there will be easily occur many bugs and works if we force to transform kebab-case component and normal scoped
    //  css to camelCase component and  v-deep css.

     return <my-component  class="font-20"/>
  }
}
</script>
<style scoped>
// it won't work
.font-20 {
  font-size: 20px;
}
// it will work
::v-deep .font-20 {
  font-size: 40px;
} 
</style> 
```
@sodatea @antfu 