### PR TITLE
feat(babel-preset-jsx): Make `importSource` API configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # vuepress build output
 .vuepress/dist
+
+# webstorm
+.idea

--- a/packages/babel-preset-jsx/README.md
+++ b/packages/babel-preset-jsx/README.md
@@ -47,7 +47,9 @@ Options are:
   - The default value is `false`;
   - When set to `'auto'` (or `true`), it will detect the Vue version in the project. If it's >= 2.7, it will import the composition utilities from `vue`, otherwise from `@vue/composition-api`;
   - When set to `'native'` (or `'naruto'`), it will always import the composition utilities from `vue`
-  - When set to `plugin`, it will always import the composition utilities from `@vue/composition-api`
+  - When set to `plugin`, it will always import the composition utilities from `@vue/composition-api`, but it will redirect to `'vue'` itself when the vue version is `2.7.x`
+  - When set to `vue-demi`, it will always import the composition utilities from `vue-demi`
+  - When set to an object like `{ importSource: string; }`, it will always import the composition utilities from the importSource you set
 - `functional` [@vue/babel-sugar-functional-vue](../babel-sugar-functional-vue/README.md) - Functional components syntactic sugar
 - `injectH` [@vue/babel-sugar-inject-h](../babel-sugar-inject-h/README.md) - Automatic `h` injection syntactic sugar
 - `vModel` [@vue/babel-sugar-v-model](../babel-sugar-v-model/README.md) - `vModel` syntactic sugar

--- a/packages/babel-preset-jsx/src/index.js
+++ b/packages/babel-preset-jsx/src/index.js
@@ -13,24 +13,32 @@ export default (_, {
   vOn = true,
   compositionAPI = false
 } = {}) => {
-  // compositionAPI: 'auto' | 'native' | 'plugin' | false
+  // compositionAPI: 'auto' | 'native' | 'plugin' | 'vue-demi' | false | { importSource: string; }
   // legacy: compositionAPI: true (equivalent to 'auto')
   // bonus:  compositionAPI: 'naruto' (equivalent to 'native')
   let injectHPlugin = babelSugarInjectH
   let importSource = '@vue/composition-api'
 
   if (compositionAPI) {
-    if (compositionAPI === 'native' || compositionAPI === 'naruto') {
+    if (['native', 'naruto'].includes(compositionAPI)) {
       importSource = 'vue'
     }
 
-    if (compositionAPI === 'auto' || compositionAPI === true) {
+    if (compositionAPI === 'vue-demi') {
+      importSource = 'vue-demi'
+    }
+
+    if (['auto', true].includes(compositionAPI)) {
       try {
         const vueVersion = require('vue/package.json').version
         if (vueVersion.startsWith('2.7')) {
           importSource = 'vue'
         }
-      } catch (e) {}
+      } catch (e) { }
+    }
+
+    if (typeof compositionAPI === 'object' && compositionAPI.importSource) {
+      importSource = compositionAPI.importSource
     }
 
     injectHPlugin = [babelSugarCompositionApiInjectH, { importSource }]


### PR DESCRIPTION
I've encountered a situation that I need to make my lib compatible with both `vue 2.6` and `vue2.7` at the same time, so I used `vue-demi`.
I should ensure that all of imports from vue should be redirected to `vue-demi` which makes `vue-demi` work, but the plugin `@vitejs/plugin-vue2-jsx` which used `@vue/babel-preset-jsx` inside can't pass some options to control the import source. It will auto inject `import {h} from 'vue'` statements to the build result, which doesn't meet my needs.
So I create this PR to extend the abilities of this plugin, wish I can pass `{ compositionAPI: { importSource: 'vue-demi' } }` to the `@vitejs/plugin-vue2-jsx` with using `vite`.
Please take a code review, thanks!