### PR TITLE
fix: add `rawName` to directive parse

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -152,11 +152,13 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
   let name
   let modifiers
   let argument
+  let rawName
   if (t.isJSXNamespacedName(namePath)) {
     name = `${namePath.get('namespace.name').node}:${namePath.get('name.name').node}`
   } else {
     name = namePath.get('name').node
   }
+  rawName = name
   if (prefixes.includes(name) && t.isJSXExpressionContainer(path.get('value'))) {
     return t.JSXSpreadAttribute(t.objectExpression([t.objectProperty(t.stringLiteral(name), path.get('value').node.expression)]))
   }
@@ -188,6 +190,7 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
 
   value._argument = argument
   value._modifiers = modifiers
+  value._rawName = rawName
 
   if (rootAttributes.includes(name)) {
     attributes[name] = value
@@ -294,6 +297,9 @@ const transformDirectives = (t, directives) =>
     directives.properties.map(directive =>
       t.objectExpression([
         t.objectProperty(t.identifier('name'), directive.key),
+        ...(directive.value._rawName
+            ? [t.objectProperty(t.identifier('rawName'), t.stringLiteral(directive.value._rawName))]
+            : []),
         t.objectProperty(t.identifier('value'), directive.value),
         ...(directive.value._argument
           ? [t.objectProperty(t.identifier('arg'), t.stringLiteral(directive.value._argument))]

--- a/packages/babel-plugin-transform-vue-jsx/test/functional.js
+++ b/packages/babel-plugin-transform-vue-jsx/test/functional.js
@@ -250,8 +250,8 @@ test('Custom directives', t => {
   })
 
   t.is(wrapper.vnode.data.directives.length, 2)
-  t.deepEqual(wrapper.vnode.data.directives[0], { def: directive, modifiers: {}, name: 'test', value: 123 })
-  t.deepEqual(wrapper.vnode.data.directives[1], { def: directive, modifiers: {}, name: 'other', value: 234 })
+  t.deepEqual(wrapper.vnode.data.directives[0], { def: directive, modifiers: {}, name: 'test', rawName: 'v-test', value: 123 })
+  t.deepEqual(wrapper.vnode.data.directives[1], { def: directive, modifiers: {}, name: 'other', rawName: 'vOther', value: 234 })
 })
 
 test('xlink:href', t => {

--- a/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
+++ b/packages/babel-plugin-transform-vue-jsx/test/snapshot.js
@@ -232,21 +232,33 @@ render(h => h("div", _mergeJSXProps([{}, spread, {
   },
   {
     name: 'Directives',
-    from: `render(h => <div v-test={ 123 } vSomething_modifier={ 1234 } vOtherStuff:argument_modifier1_modifier2={ 234 } />)`,
+    from: `render(h => <div v-test={ 123 } vSomething_modifier={ 1234 } vOtherStuff:argument_modifier1_modifier2={ 234 } vOtherStuff:argument2_modifier1_modifier2={ 2345 } />)`,
     to: `render(h => h("div", {
   "directives": [{
     name: "test",
+    rawName: "v-test",
     value: 123
   }, {
     name: "something",
+    rawName: "vSomething_modifier",
     value: 1234,
     modifiers: {
       "modifier": true
     }
   }, {
     name: "other-stuff",
+    rawName: "vOtherStuff:argument_modifier1_modifier2",
     value: 234,
     arg: "argument",
+    modifiers: {
+      "modifier1": true,
+      "modifier2": true
+    }
+  }, {
+    name: "other-stuff",
+    rawName: "vOtherStuff:argument2_modifier1_modifier2",
+    value: 2345,
+    arg: "argument2",
     modifiers: {
       "modifier1": true,
       "modifier2": true


### PR DESCRIPTION
When Vue normalizeDirectives, it will call `getRawDirName` to get `rawName` that is as the unique key of the directive. `babel-plugin-transform-vue-jsx` does not handle it in a correct way.
```javascript
function normalizeDirectives (
  dirs: ?Array<VNodeDirective>,
  vm: Component
): { [key: string]: VNodeDirective } {
  const res = Object.create(null)
  if (!dirs) {
    // $flow-disable-line
    return res
  }
  let i, dir
  for (i = 0; i < dirs.length; i++) {
    dir = dirs[i]
    if (!dir.modifiers) {
      // $flow-disable-line
      dir.modifiers = emptyModifiers
    }
    res[getRawDirName(dir)] = dir
    dir.def = resolveAsset(vm.$options, 'directives', dir.name, true)
  }
  // $flow-disable-line
  return res
}

function getRawDirName (dir: VNodeDirective): string {
  return dir.rawName || `${dir.name}.${Object.keys(dir.modifiers || {}).join('.')}`
}
```