### PR TITLE
fix: prevent inject duplicate h variable

### DIFF
--- a/packages/babel-sugar-inject-h/test/test.js
+++ b/packages/babel-sugar-inject-h/test/test.js
@@ -120,6 +120,55 @@ const tests = [
 
 };`,
   },
+  {
+    name: 'Has Defined H Variable in object method',
+    from: `const obj = {
+      getTextNode() {
+        const h = this.$createElement
+        return <div>test</div>
+      }
+    }`,
+    to: `const obj = {
+  getTextNode() {
+    const h = this.$createElement;
+    return <div>test</div>;
+  }
+
+};`
+  },
+  {
+    name: 'Has Defined H Variable in render method',
+    from: `const obj = {
+      render() {
+        const h = arguments[0];
+        return <div>test</div>
+      }
+    }`,
+    to: `const obj = {
+  render() {
+    const h = arguments[0];
+    return <div>test</div>;
+  }
+
+};`,
+  },
+  {
+    name: 'Has Defined not H Variable in render method',
+    from: `const obj = {
+      render() {
+        const a = arguments[0];
+        return <div>test</div>
+      }
+    }`,
+    to: `const obj = {
+  render() {
+    const h = arguments[0];
+    const a = arguments[0];
+    return <div>test</div>;
+  }
+
+};`
+  }
 ]
 
 tests.forEach(({ name, from, to }) => test(name, async t => t.is(await transpile(from), to)))


### PR DESCRIPTION
[issues 297](https://github.com/vuejs/jsx-vue2/issues/297)

I think this MR could do two things.
1. if user defined h variable by himself and init is $createElement or arguments[0], plugin should not inject  h agian.
2. solve issues 297, two preset includes plugin，then h inject twice.