### PR TITLE
fix(babel-sugar-v-on): fix native modifier invalided when used with other modifiers

### DIFF
--- a/packages/babel-sugar-v-on/src/index.js
+++ b/packages/babel-sugar-v-on/src/index.js
@@ -275,7 +275,7 @@ export default function(babel) {
         t.jSXSpreadAttribute(
           t.objectExpression([
             t.objectProperty(
-              t.identifier('on'),
+              t.identifier(isNative ? 'nativeOn' : 'on'),
               t.objectExpression([t.objectProperty(t.stringLiteral(event), expression)]),
             ),
           ]),

--- a/packages/babel-sugar-v-on/test/snapshot.js
+++ b/packages/babel-sugar-v-on/test/snapshot.js
@@ -30,6 +30,15 @@ const tests = [
     to: `render(h => <div nativeOn-click={foo}>test</div>);`,
   },
   {
+    name: 'v-on:click_native_capture',
+    from: `render(h => <div v-on:click_native_capture={foo}>test</div>)`,
+    to: `render(h => <div {...{
+  nativeOn: {
+    "!click": foo
+  }
+}}>test</div>);`,
+  },
+  {
     name: 'v-on:click with arrow function expression',
     from: `render(h => <div v-on:click={myEvent => foo(1, 2, 3, $myEvent)}>test</div>)`,
     to: `render(h => <div on-click={myEvent => foo(1, 2, 3, $myEvent)}>test</div>);`,


### PR DESCRIPTION
Native modifier invalided when used with other modifiers.
For example: `vOn:click_native_capture`