### PR TITLE
过滤掉jsx属性中的换行符

### DIFF
--- a/packages/babel-plugin-transform-vue-jsx/src/index.js
+++ b/packages/babel-plugin-transform-vue-jsx/src/index.js
@@ -173,6 +173,7 @@ const parseAttributeJSXAttribute = (t, path, attributes, tagName, elementType) =
   if (!valuePath.node) {
     value = t.booleanLiteral(true)
   } else if (t.isStringLiteral(valuePath)) {
+    valuePath.node.value = valuePath.node.value.replace(/\n\s+/g, ' ')
     value = valuePath.node
   } else {
     /* istanbul ignore else */


### PR DESCRIPTION

```
  render (h) {
      return (
        <div style='
                line-height: 16px;
                text-align: left;
              '>
              </div>
    )}
```
以上jsx如果不过滤换行符，会报错： Unterminated string constant


在老版本jsx插件中, 是会过滤掉属性中的换行符，老版本参考：
[ [babel-plugin-transform-vue-jsx](https://github.com/vuejs/babel-plugin-transform-vue-jsx/tree/master)
/index.js](https://github.com/vuejs/babel-plugin-transform-vue-jsx/blob/6ad7487579094cc188d470171af8f62335193896/index.js#L207)